### PR TITLE
Add conversation service with REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ Set your OpenAI API key in the `OPENAI_API_KEY` environment variable and run:
 ```bash
 mvn spring-boot:run
 ```
+
+Once running you can chat with the AI over HTTP:
+
+```bash
+curl -X POST http://localhost:8080/chat/session1 -d 'Hello'
+```
+
+Use the same session id to continue the conversation.

--- a/src/main/java/com/example/adapter/ChatController.java
+++ b/src/main/java/com/example/adapter/ChatController.java
@@ -1,0 +1,24 @@
+package com.example.adapter;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.application.ConversationService;
+
+@RestController
+public class ChatController {
+
+    private final ConversationService conversationService;
+
+    public ChatController(ConversationService conversationService) {
+        this.conversationService = conversationService;
+    }
+
+    @PostMapping("/chat/{sessionId}")
+    public ResponseEntity<String> chat(@PathVariable String sessionId, @RequestBody String message) {
+        return ResponseEntity.ok(conversationService.chat(sessionId, message));
+    }
+}

--- a/src/main/java/com/example/application/ConversationService.java
+++ b/src/main/java/com/example/application/ConversationService.java
@@ -1,0 +1,32 @@
+package com.example.application;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.ai.chat.prompt.AssistantMessage;
+import org.springframework.ai.chat.prompt.ChatMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.UserMessage;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConversationService {
+
+    private final ChatUseCase chatUseCase;
+    private final Map<String, List<ChatMessage>> sessions = new HashMap<>();
+
+    public ConversationService(ChatUseCase chatUseCase) {
+        this.chatUseCase = chatUseCase;
+    }
+
+    public synchronized String chat(String sessionId, String message) {
+        List<ChatMessage> history = sessions.computeIfAbsent(sessionId, id -> new ArrayList<>());
+        history.add(new UserMessage(message));
+        Prompt prompt = new Prompt(history);
+        String response = chatUseCase.chat(prompt);
+        history.add(new AssistantMessage(response));
+        return response;
+    }
+}

--- a/src/test/java/com/example/application/ConversationServiceTests.java
+++ b/src/test/java/com/example/application/ConversationServiceTests.java
@@ -1,0 +1,37 @@
+package com.example.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.chat.prompt.ChatMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.UserMessage;
+
+class ConversationServiceTests {
+
+    @Test
+    void conversationStoresHistoryPerSession() {
+        ChatUseCase useCase = mock(ChatUseCase.class);
+        when(useCase.chat(any())).thenReturn("a").thenReturn("b");
+
+        ConversationService service = new ConversationService(useCase);
+        assertEquals("a", service.chat("1", "hello"));
+        assertEquals("b", service.chat("1", "how are you?"));
+
+        ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+        verify(useCase, times(2)).chat(captor.capture());
+        List<Prompt> prompts = captor.getAllValues();
+        // first call has only the user message
+        assertEquals(List.of(new UserMessage("hello")), prompts.get(0).getMessages());
+        // second call should contain first user and assistant plus new user
+        List<ChatMessage> second = prompts.get(1).getMessages();
+        assertEquals(3, second.size());
+        assertEquals("hello", second.get(0).getContent());
+        assertEquals("a", second.get(1).getContent());
+        assertEquals("how are you?", second.get(2).getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- implement ConversationService to keep chat history across sessions
- expose new `/chat/{sessionId}` REST endpoint
- document HTTP API in README
- test ConversationService behavior

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fbe7f52483288918d26aba087cca