### PR TITLE
Enhance chat features with tools and RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ This project demonstrates basic usage of **Spring AI** with function calls and
 retrieval–augmented generation (RAG). The application is built with Maven and
 uses Spring Boot.
 
-The source code follows a simple layered design. AI interactions, RAG logic and
-tool functions are implemented in separate service classes under
-`com.example.service` for easier extension and testing.
+The source code follows a layered design. AI interactions, RAG logic and tool
+functions are implemented in dedicated services under `com.example.application`
+for easier extension and testing. Conversations are tracked per session and can
+be cleared using an HTTP `DELETE` request.
 
 ### Running
 
@@ -21,4 +22,11 @@ Once running you can chat with the AI over HTTP:
 curl -X POST http://localhost:8080/chat/session1 -d 'Hello'
 ```
 
-Use the same session id to continue the conversation.
+Use the same session id to continue the conversation. To reset a conversation
+send:
+
+```bash
+curl -X DELETE http://localhost:8080/chat/session1
+```
+
+You can also call simple tools such as the current time using a `/time` command.

--- a/src/main/java/com/example/adapter/ChatController.java
+++ b/src/main/java/com/example/adapter/ChatController.java
@@ -1,6 +1,7 @@
 package com.example.adapter;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,5 +21,11 @@ public class ChatController {
     @PostMapping("/chat/{sessionId}")
     public ResponseEntity<String> chat(@PathVariable String sessionId, @RequestBody String message) {
         return ResponseEntity.ok(conversationService.chat(sessionId, message));
+    }
+
+    @DeleteMapping("/chat/{sessionId}")
+    public ResponseEntity<Void> clear(@PathVariable String sessionId) {
+        conversationService.clear(sessionId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/application/PromptService.java
+++ b/src/main/java/com/example/application/PromptService.java
@@ -1,0 +1,33 @@
+package com.example.application;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.ai.chat.prompt.ChatMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.SystemMessage;
+import org.springframework.ai.chat.prompt.UserMessage;
+import org.springframework.ai.document.Document;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PromptService {
+
+    private final DocumentUseCase documentUseCase;
+
+    public PromptService(DocumentUseCase documentUseCase) {
+        this.documentUseCase = documentUseCase;
+    }
+
+    public Prompt buildPrompt(List<ChatMessage> history, String userMessage) {
+        List<ChatMessage> messages = new ArrayList<>(history);
+        messages.add(new UserMessage(userMessage));
+
+        List<Document> docs = documentUseCase.search(userMessage);
+        if (!docs.isEmpty()) {
+            messages.add(new SystemMessage("Context: " + docs.get(0).getText()));
+        }
+
+        return new Prompt(messages);
+    }
+}

--- a/src/main/java/com/example/application/ToolService.java
+++ b/src/main/java/com/example/application/ToolService.java
@@ -1,0 +1,22 @@
+package com.example.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ToolService {
+
+    private final TimeUseCase timeUseCase;
+
+    public ToolService(TimeUseCase timeUseCase) {
+        this.timeUseCase = timeUseCase;
+    }
+
+    public String handle(String message) {
+        if (message.startsWith("/time")) {
+            String[] parts = message.split("\\s+", 2);
+            String zone = parts.length > 1 ? parts[1] : null;
+            return timeUseCase.currentTime(zone);
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/example/application/ConversationServiceTests.java
+++ b/src/test/java/com/example/application/ConversationServiceTests.java
@@ -11,6 +11,9 @@ import org.springframework.ai.chat.prompt.ChatMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.UserMessage;
 
+import com.example.application.PromptService;
+import com.example.application.ToolService;
+
 class ConversationServiceTests {
 
     @Test
@@ -18,7 +21,12 @@ class ConversationServiceTests {
         ChatUseCase useCase = mock(ChatUseCase.class);
         when(useCase.chat(any())).thenReturn("a").thenReturn("b");
 
-        ConversationService service = new ConversationService(useCase);
+        PromptService promptService = mock(PromptService.class);
+        when(promptService.buildPrompt(anyList(), anyString()))
+                .thenAnswer(inv -> new Prompt(inv.getArgument(0)));
+
+        ToolService toolService = mock(ToolService.class);
+        ConversationService service = new ConversationService(useCase, promptService, toolService);
         assertEquals("a", service.chat("1", "hello"));
         assertEquals("b", service.chat("1", "how are you?"));
 

--- a/src/test/java/com/example/application/PromptServiceTests.java
+++ b/src/test/java/com/example/application/PromptServiceTests.java
@@ -1,0 +1,27 @@
+package com.example.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.prompt.ChatMessage;
+import org.springframework.ai.chat.prompt.SystemMessage;
+import org.springframework.ai.document.Document;
+
+class PromptServiceTests {
+
+    @Test
+    void buildPromptAddsContext() {
+        DocumentUseCase documentUseCase = mock(DocumentUseCase.class);
+        when(documentUseCase.search("q")).thenReturn(List.of(new Document("id", "doc")));
+
+        PromptService service = new PromptService(documentUseCase);
+        var prompt = service.buildPrompt(List.of(), "q");
+        List<ChatMessage> messages = prompt.getMessages();
+        assertEquals(2, messages.size());
+        assertEquals("q", messages.get(0).getContent());
+        assertEquals("Context: doc", ((SystemMessage) messages.get(1)).getContent());
+    }
+}

--- a/src/test/java/com/example/application/ToolServiceTests.java
+++ b/src/test/java/com/example/application/ToolServiceTests.java
@@ -1,0 +1,19 @@
+package com.example.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+
+class ToolServiceTests {
+
+    @Test
+    void handleDelegatesToTimeUseCase() {
+        TimeUseCase timeUseCase = mock(TimeUseCase.class);
+        when(timeUseCase.currentTime("UTC")).thenReturn("now");
+
+        ToolService service = new ToolService(timeUseCase);
+        assertEquals("now", service.handle("/time UTC"));
+        verify(timeUseCase).currentTime("UTC");
+    }
+}


### PR DESCRIPTION
## Summary
- allow clearing conversations via HTTP DELETE
- add prompt management with RAG context
- support `/time` tool command
- expose new services for prompts and tools
- update conversation tests and add new unit tests
- document the new capabilities

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845082840048328ae346ec418af80d7