### PR TITLE
Add configurable prompt templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ curl -X DELETE http://localhost:8080/chat/session1
 ```
 
 You can also call simple tools such as the current time using a `/time` command.
+
+### Configuring Prompts
+
+Prompt templates are defined in `application.yaml` under the `app.prompt.templates`
+section. Placeholders like `{context}` are replaced at runtime. You can add
+additional templates and reference them from the application code.

--- a/src/main/java/com/example/AiApplication.java
+++ b/src/main/java/com/example/AiApplication.java
@@ -13,11 +13,13 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 import com.example.application.ChatUseCase;
 import com.example.application.DocumentUseCase;
 
 @SpringBootApplication
+@EnableConfigurationProperties(com.example.application.PromptProperties.class)
 public class AiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/application/PromptProperties.java
+++ b/src/main/java/com/example/application/PromptProperties.java
@@ -1,0 +1,19 @@
+package com.example.application;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.prompt")
+public class PromptProperties {
+    private Map<String, String> templates = new HashMap<>();
+
+    public Map<String, String> getTemplates() {
+        return templates;
+    }
+
+    public void setTemplates(Map<String, String> templates) {
+        this.templates = templates;
+    }
+}

--- a/src/main/java/com/example/application/PromptService.java
+++ b/src/main/java/com/example/application/PromptService.java
@@ -2,6 +2,7 @@ package com.example.application;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.ai.chat.prompt.ChatMessage;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -14,9 +15,11 @@ import org.springframework.stereotype.Service;
 public class PromptService {
 
     private final DocumentUseCase documentUseCase;
+    private final PromptTemplateService templateService;
 
-    public PromptService(DocumentUseCase documentUseCase) {
+    public PromptService(DocumentUseCase documentUseCase, PromptTemplateService templateService) {
         this.documentUseCase = documentUseCase;
+        this.templateService = templateService;
     }
 
     public Prompt buildPrompt(List<ChatMessage> history, String userMessage) {
@@ -25,7 +28,11 @@ public class PromptService {
 
         List<Document> docs = documentUseCase.search(userMessage);
         if (!docs.isEmpty()) {
-            messages.add(new SystemMessage("Context: " + docs.get(0).getText()));
+            String context = templateService.render("context", Map.of("context", docs.get(0).getText()));
+            if (context == null) {
+                context = "Context: " + docs.get(0).getText();
+            }
+            messages.add(new SystemMessage(context));
         }
 
         return new Prompt(messages);

--- a/src/main/java/com/example/application/PromptTemplateService.java
+++ b/src/main/java/com/example/application/PromptTemplateService.java
@@ -1,0 +1,27 @@
+package com.example.application;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PromptTemplateService {
+
+    private final PromptProperties properties;
+
+    public PromptTemplateService(PromptProperties properties) {
+        this.properties = properties;
+    }
+
+    public String render(String name, Map<String, String> variables) {
+        String template = properties.getTemplates().get(name);
+        if (template == null) {
+            return null;
+        }
+        String result = template;
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            result = result.replace("{" + entry.getKey() + "}", entry.getValue());
+        }
+        return result;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,4 @@
+app:
+  prompt:
+    templates:
+      context: "Context: {context}"

--- a/src/test/java/com/example/application/PromptServiceTests.java
+++ b/src/test/java/com/example/application/PromptServiceTests.java
@@ -17,7 +17,10 @@ class PromptServiceTests {
         DocumentUseCase documentUseCase = mock(DocumentUseCase.class);
         when(documentUseCase.search("q")).thenReturn(List.of(new Document("id", "doc")));
 
-        PromptService service = new PromptService(documentUseCase);
+        PromptProperties properties = new PromptProperties();
+        properties.getTemplates().put("context", "Context: {context}");
+        PromptTemplateService templateService = new PromptTemplateService(properties);
+        PromptService service = new PromptService(documentUseCase, templateService);
         var prompt = service.buildPrompt(List.of(), "q");
         List<ChatMessage> messages = prompt.getMessages();
         assertEquals(2, messages.size());


### PR DESCRIPTION
## Summary
- enable configurable prompt templates via PromptProperties
- add PromptTemplateService for placeholder replacement
- inject new service into PromptService
- document the new configuration in README

## Testing
- `mvn -q test` *(fails: Plugin resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_684509b0499083289a18799b7c935198