### PR TITLE
Add template-based RAG and tool prompts

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,3 +2,6 @@ app:
   prompt:
     templates:
       context: "Context: {context}"
+      rag: "Answer using this information: {context}"
+      functioncall: "Use tools with /commands when needed"
+      mcp: "Conversation so far: {history}"

--- a/src/test/java/com/example/application/PromptServiceTests.java
+++ b/src/test/java/com/example/application/PromptServiceTests.java
@@ -8,23 +8,29 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.prompt.ChatMessage;
 import org.springframework.ai.chat.prompt.SystemMessage;
+import org.springframework.ai.chat.prompt.UserMessage;
 import org.springframework.ai.document.Document;
 
 class PromptServiceTests {
 
     @Test
-    void buildPromptAddsContext() {
+    void buildPromptAddsTemplates() {
         DocumentUseCase documentUseCase = mock(DocumentUseCase.class);
         when(documentUseCase.search("q")).thenReturn(List.of(new Document("id", "doc")));
 
         PromptProperties properties = new PromptProperties();
-        properties.getTemplates().put("context", "Context: {context}");
+        properties.getTemplates().put("functioncall", "TOOLS");
+        properties.getTemplates().put("mcp", "History: {history}");
+        properties.getTemplates().put("rag", "RAG: {context}");
         PromptTemplateService templateService = new PromptTemplateService(properties);
         PromptService service = new PromptService(documentUseCase, templateService);
-        var prompt = service.buildPrompt(List.of(), "q");
+        var prompt = service.buildPrompt(List.of(new UserMessage("hi")), "q");
         List<ChatMessage> messages = prompt.getMessages();
-        assertEquals(2, messages.size());
-        assertEquals("q", messages.get(0).getContent());
-        assertEquals("Context: doc", ((SystemMessage) messages.get(1)).getContent());
+        assertEquals(5, messages.size());
+        assertEquals("TOOLS", ((SystemMessage) messages.get(0)).getContent());
+        assertEquals("History: hi", ((SystemMessage) messages.get(1)).getContent());
+        assertEquals("hi", messages.get(2).getContent());
+        assertEquals("q", messages.get(3).getContent());
+        assertEquals("RAG: doc", ((SystemMessage) messages.get(4)).getContent());
     }
 }


### PR DESCRIPTION
## Summary
- support new `rag`, `functioncall` and `mcp` templates
- incorporate the templates when building prompts
- update tests for new behaviour

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_68453ad745f4832892b6c8d456b8806f