### PR TITLE
Implement scenario based prompt configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You can also call simple tools such as the current time using a `/time` command.
 
 ### Configuring Prompts
 
-Prompt templates are defined in `application.yaml` under the `app.prompt.templates`
-section. Placeholders like `{context}` are replaced at runtime. You can add
-additional templates and reference them from the application code.
+Prompt templates are defined in `application.yaml` under the `app.prompt` section.
+Simple values live under `templates` while scenario specific prompts (e.g. RAG or
+multi turn chat) are configured under `scenarios`. Placeholders like `{context}`
+or `{history}` are replaced at runtime. You can add additional templates or
+scenarios and reference them from the application code.

--- a/src/main/java/com/example/application/PromptProperties.java
+++ b/src/main/java/com/example/application/PromptProperties.java
@@ -7,7 +7,39 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.prompt")
 public class PromptProperties {
+
+    public static class Scenario {
+        private String system;
+        private String user;
+        private String constraints;
+
+        public String getSystem() {
+            return system;
+        }
+
+        public void setSystem(String system) {
+            this.system = system;
+        }
+
+        public String getUser() {
+            return user;
+        }
+
+        public void setUser(String user) {
+            this.user = user;
+        }
+
+        public String getConstraints() {
+            return constraints;
+        }
+
+        public void setConstraints(String constraints) {
+            this.constraints = constraints;
+        }
+    }
+
     private Map<String, String> templates = new HashMap<>();
+    private Map<String, Scenario> scenarios = new HashMap<>();
 
     public Map<String, String> getTemplates() {
         return templates;
@@ -15,5 +47,13 @@ public class PromptProperties {
 
     public void setTemplates(Map<String, String> templates) {
         this.templates = templates;
+    }
+
+    public Map<String, Scenario> getScenarios() {
+        return scenarios;
+    }
+
+    public void setScenarios(Map<String, Scenario> scenarios) {
+        this.scenarios = scenarios;
     }
 }

--- a/src/main/java/com/example/application/PromptTemplateService.java
+++ b/src/main/java/com/example/application/PromptTemplateService.java
@@ -13,11 +13,19 @@ public class PromptTemplateService {
         this.properties = properties;
     }
 
+    public PromptProperties.Scenario getScenario(String name) {
+        return properties.getScenarios().get(name);
+    }
+
     public String render(String name, Map<String, String> variables) {
         String template = properties.getTemplates().get(name);
         if (template == null) {
             return null;
         }
+        return renderTemplate(template, variables);
+    }
+
+    public String renderTemplate(String template, Map<String, String> variables) {
         String result = template;
         for (Map.Entry<String, String> entry : variables.entrySet()) {
             result = result.replace("{" + entry.getKey() + "}", entry.getValue());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,9 @@ app:
   prompt:
     templates:
       context: "Context: {context}"
-      rag: "Answer using this information: {context}"
       functioncall: "Use tools with /commands when needed"
-      mcp: "Conversation so far: {history}"
+    scenarios:
+      rag:
+        system: "Answer using this information: {context}"
+      mcp:
+        system: "Conversation so far: {history}"


### PR DESCRIPTION
## Summary
- restructure prompt configuration to support scenarios
- adjust prompt service to use RAG and MCP scenarios
- document new configuration options in README

## Testing
- `mvn -q test` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68454308bfa083288375c3749673e16b