### PR TITLE
Add ReAct prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AI Framework
-This project demonstrates basic usage of **Spring AI** with function calls and
-retrieval–augmented generation (RAG). The application is built with Maven and
-uses Spring Boot.
+This project demonstrates basic usage of **Spring AI** with function calls,
+retrieval–augmented generation (RAG) and a simple implementation of the
+ReAct pattern. The application is built with Maven and uses Spring Boot.
 
 The source code follows a layered design. AI interactions, RAG logic and tool
 functions are implemented in dedicated services under `com.example.application`
@@ -33,6 +33,9 @@ You can also call simple tools such as the current time using a `/time` command.
 
 ### Configuring Prompts
 
-Prompt templates are defined in `application.yaml` under the `app.prompt.templates`
-section. Placeholders like `{context}` are replaced at runtime. You can add
-additional templates and reference them from the application code.
+Prompt templates are defined in `application.yaml` under the
+`app.prompt.templates` section. Placeholders like `{context}` are replaced at
+runtime. The default configuration includes templates for RAG context, tool
+instructions and a `react` template that guides the model to respond using the
+ReAct style. You can add additional templates and reference them from the
+application code.

--- a/src/main/java/com/example/application/PromptService.java
+++ b/src/main/java/com/example/application/PromptService.java
@@ -31,6 +31,11 @@ public class PromptService {
             messages.add(new SystemMessage(tools));
         }
 
+        String react = templateService.render("react", Map.of());
+        if (react != null) {
+            messages.add(new SystemMessage(react));
+        }
+
         if (!history.isEmpty()) {
             String joined = history.stream()
                     .map(ChatMessage::getContent)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,3 +5,4 @@ app:
       rag: "Answer using this information: {context}"
       functioncall: "Use tools with /commands when needed"
       mcp: "Conversation so far: {history}"
+      react: "Respond using the ReAct format with Thought, Action and Observation"

--- a/src/test/java/com/example/application/PromptServiceTests.java
+++ b/src/test/java/com/example/application/PromptServiceTests.java
@@ -20,17 +20,19 @@ class PromptServiceTests {
 
         PromptProperties properties = new PromptProperties();
         properties.getTemplates().put("functioncall", "TOOLS");
+        properties.getTemplates().put("react", "REACT");
         properties.getTemplates().put("mcp", "History: {history}");
         properties.getTemplates().put("rag", "RAG: {context}");
         PromptTemplateService templateService = new PromptTemplateService(properties);
         PromptService service = new PromptService(documentUseCase, templateService);
         var prompt = service.buildPrompt(List.of(new UserMessage("hi")), "q");
         List<ChatMessage> messages = prompt.getMessages();
-        assertEquals(5, messages.size());
+        assertEquals(6, messages.size());
         assertEquals("TOOLS", ((SystemMessage) messages.get(0)).getContent());
-        assertEquals("History: hi", ((SystemMessage) messages.get(1)).getContent());
-        assertEquals("hi", messages.get(2).getContent());
-        assertEquals("q", messages.get(3).getContent());
-        assertEquals("RAG: doc", ((SystemMessage) messages.get(4)).getContent());
+        assertEquals("REACT", ((SystemMessage) messages.get(1)).getContent());
+        assertEquals("History: hi", ((SystemMessage) messages.get(2)).getContent());
+        assertEquals("hi", messages.get(3).getContent());
+        assertEquals("q", messages.get(4).getContent());
+        assertEquals("RAG: doc", ((SystemMessage) messages.get(5)).getContent());
     }
 }


### PR DESCRIPTION
## Summary
- support an optional `react` template to guide the model in ReAct style
- update default prompt configuration
- explain ReAct support in README
- adjust unit tests

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684544116dfc83289b9b48168613464d