### PR TITLE
Add simple local vectorization engine

### DIFF
--- a/src/main/java/com/example/adapter/LocalVectorStoreAdapter.java
+++ b/src/main/java/com/example/adapter/LocalVectorStoreAdapter.java
@@ -1,0 +1,49 @@
+package com.example.adapter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.ai.document.Document;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import com.example.domain.DocumentStorePort;
+
+/**
+ * Simple in-memory vector store using {@link LocalVectorizer}.
+ */
+@Component
+@Primary
+public class LocalVectorStoreAdapter implements DocumentStorePort {
+
+    private final Map<String, Document> documents = new HashMap<>();
+    private final Map<String, double[]> vectors = new HashMap<>();
+    private final LocalVectorizer vectorizer = new LocalVectorizer();
+
+    @Override
+    public synchronized void addDocuments(List<Document> docs) {
+        for (Document d : docs) {
+            documents.put(d.getId(), d);
+            vectors.put(d.getId(), vectorizer.vectorize(d.getText()));
+        }
+    }
+
+    @Override
+    public synchronized List<Document> search(String query) {
+        double[] qv = vectorizer.vectorize(query);
+        String bestId = null;
+        double best = -1.0;
+        for (Map.Entry<String, double[]> e : vectors.entrySet()) {
+            double score = vectorizer.cosineSimilarity(qv, e.getValue());
+            if (score > best) {
+                best = score;
+                bestId = e.getKey();
+            }
+        }
+        if (bestId == null) {
+            return List.of();
+        }
+        return List.of(documents.get(bestId));
+    }
+}

--- a/src/main/java/com/example/adapter/LocalVectorizer.java
+++ b/src/main/java/com/example/adapter/LocalVectorizer.java
@@ -1,0 +1,47 @@
+package com.example.adapter;
+
+/**
+ * Very small helper that turns text into a vector of character frequencies.
+ */
+public class LocalVectorizer {
+
+    public double[] vectorize(String text) {
+        double[] vec = new double[26];
+        if (text == null) {
+            return vec;
+        }
+        text = text.toLowerCase();
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c >= 'a' && c <= 'z') {
+                vec[c - 'a'] += 1;
+            }
+        }
+        double norm = 0.0;
+        for (double v : vec) {
+            norm += v * v;
+        }
+        norm = Math.sqrt(norm);
+        if (norm > 0) {
+            for (int i = 0; i < vec.length; i++) {
+                vec[i] /= norm;
+            }
+        }
+        return vec;
+    }
+
+    public double cosineSimilarity(double[] a, double[] b) {
+        double dot = 0.0;
+        double normA = 0.0;
+        double normB = 0.0;
+        for (int i = 0; i < a.length; i++) {
+            dot += a[i] * b[i];
+            normA += a[i] * a[i];
+            normB += b[i] * b[i];
+        }
+        if (normA == 0 || normB == 0) {
+            return 0;
+        }
+        return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+    }
+}

--- a/src/test/java/com/example/adapter/LocalVectorStoreAdapterTests.java
+++ b/src/test/java/com/example/adapter/LocalVectorStoreAdapterTests.java
@@ -1,0 +1,20 @@
+package com.example.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+class LocalVectorStoreAdapterTests {
+
+    @Test
+    void searchReturnsMostSimilarDocument() {
+        LocalVectorStoreAdapter store = new LocalVectorStoreAdapter();
+        store.addDocuments(List.of(new Document("1", "hello world"), new Document("2", "goodbye")));
+        var result = store.search("hello");
+        assertEquals(1, result.size());
+        assertEquals("1", result.get(0).getId());
+    }
+}


### PR DESCRIPTION
## Summary
- add `LocalVectorizer` for basic text embeddings
- implement in-memory `LocalVectorStoreAdapter`
- test vector search behaviour

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684546bb64ec8328883ac0330fc63e78